### PR TITLE
Remove style attr from JSX

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,7 +23,7 @@ class App extends React.Component {
       <Router>
         <div className="flyout">
           <Navbar />
-          <main style={{ marginTop: "4rem" }}>
+          <main>
             <Routes />
           </main>
           <Footer />

--- a/src/utilities/_base.scss
+++ b/src/utilities/_base.scss
@@ -5,7 +5,11 @@
 	justify-content: space-between;
 }
 
-// Navigation
+main{
+	padding-top: 4rem;
+}
+
+// Custom colors
 .agency-dark{
 	background-color: $agencyDark !important;
 	&.darken-1{


### PR DESCRIPTION
A JSX in-element style attribute has been removed.

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [ ] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change?
 - [x] Have you tested your changes with successful results?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**What is the current behavior? (link to any open issues here)**
- Currently, the margin-top of the main element is set in HTML as style attribute. It is 4rem. #13  


**What is the new behavior (if this is a feature change)?**
- A `padding-top` has been introduced in stead, being part of `_base.scss` #13 

